### PR TITLE
nit: return concrete types

### DIFF
--- a/api.go
+++ b/api.go
@@ -39,7 +39,7 @@ type HttpApi struct {
 //
 // Daemon api address is pulled from the $IPFS_PATH/api file.
 // If $IPFS_PATH env var is not present, it defaults to ~/.ipfs
-func NewLocalApi() (iface.CoreAPI, error) {
+func NewLocalApi() (*HttpApi, error) {
 	baseDir := os.Getenv(EnvDir)
 	if baseDir == "" {
 		baseDir = DefaultPathRoot
@@ -50,7 +50,7 @@ func NewLocalApi() (iface.CoreAPI, error) {
 
 // NewPathApi constructs new HttpApi by pulling api address from specified
 // ipfspath. Api file should be located at $ipfspath/api
-func NewPathApi(ipfspath string) (iface.CoreAPI, error) {
+func NewPathApi(ipfspath string) (*HttpApi, error) {
 	a, err := ApiAddr(ipfspath)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
This is generally considered the "better" way to do things in go. It also allows
us to expose functions like `request` at some point without changing the API
interface itself.