### PR TITLE
fix path miss in windows/add a new api create function

### DIFF
--- a/api.go
+++ b/api.go
@@ -66,19 +66,6 @@ func NewPathApi(ipfspath string) (*HttpApi, error) {
 	return NewApi(a)
 }
 
-// NewAddrApi constructs new HttpApi by pulling api address.
-// Api address should be set like /ip4/127.0.0.1/tcp/5001.
-func NewAddrApi(apiAddr string) (*HttpApi, error) {
-	a, err := ma.NewMultiaddr(strings.TrimSpace(apiAddr))
-	if err != nil {
-		if os.IsNotExist(err) {
-			err = ErrApiNotFound
-		}
-		return nil, err
-	}
-	return NewApi(a)
-}
-
 // ApiAddr reads api file in specified ipfs path
 func ApiAddr(ipfspath string) (ma.Multiaddr, error) {
 	baseDir, err := homedir.Expand(ipfspath)

--- a/api.go
+++ b/api.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	gohttp "net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	iface "github.com/ipfs/interface-go-ipfs-core"
@@ -73,7 +73,7 @@ func ApiAddr(ipfspath string) (ma.Multiaddr, error) {
 		return nil, err
 	}
 
-	apiFile := path.Join(baseDir, DefaultApiFile)
+	apiFile := filepath.Join(baseDir, DefaultApiFile)
 
 	api, err := ioutil.ReadFile(apiFile)
 	if err != nil {

--- a/api.go
+++ b/api.go
@@ -12,7 +12,7 @@ import (
 
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	caopts "github.com/ipfs/interface-go-ipfs-core/options"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 )
@@ -57,6 +57,19 @@ func NewLocalApi() (*HttpApi, error) {
 // ipfspath. Api file should be located at $ipfspath/api
 func NewPathApi(ipfspath string) (*HttpApi, error) {
 	a, err := ApiAddr(ipfspath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = ErrApiNotFound
+		}
+		return nil, err
+	}
+	return NewApi(a)
+}
+
+// NewAddrApi constructs new HttpApi by pulling api address.
+// Api address should be set like /ip4/127.0.0.1/tcp/5001.
+func NewAddrApi(apiAddr string) (*HttpApi, error) {
+	a, err := ma.NewMultiaddr(strings.TrimSpace(apiAddr))
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = ErrApiNotFound


### PR DESCRIPTION
at first, i used `go-ipfs-api` with some my change it.
but now, `go-ipfs-api` does not seem to meet my requirements.
example:
1. pin/ls always return a hash(when you have a very big database,it...),but the `go-ipfs-api` can't add
options to filter `recursive` args.

so i want change `go-ipfs-api` to this package, and fix some for use.

1. fix path miss in windows:
`path` was not always corret in windows.
2. add a new api create function: 
  fix when the ipfs running in vm and the caller client is in outer, the port is different.