### PR TITLE
Update pin.go

### DIFF
--- a/pin.go
+++ b/pin.go
@@ -86,7 +86,7 @@ func (api *PinAPI) Update(ctx context.Context, from path.Path, to path.Path, opt
 		return err
 	}
 
-	return api.core().Request("pin/update").
+	return api.core().Request("pin/update", from.String(), to.String()).
 		Option("unpin", options.Unpin).Exec(ctx, nil)
 }
 


### PR DESCRIPTION
I think `pin.Update` wasn't actually passing its arguments `from` and `to` into the `core().Request`.

Previously, every `pin.Update` request was failing with `argument "from-path" is required`; this appears to work in the super hacky five minutes of testing I just did 🙃