### PR TITLE
update pin interface to streaming core api

### DIFF
--- a/pin.go
+++ b/pin.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/interface-go-ipfs-core"
+	iface "github.com/ipfs/interface-go-ipfs-core"
 	caopts "github.com/ipfs/interface-go-ipfs-core/options"
 	"github.com/ipfs/interface-go-ipfs-core/path"
 	"github.com/pkg/errors"
@@ -24,6 +24,11 @@ type pinRefKeyList struct {
 type pin struct {
 	path path.Resolved
 	typ  string
+	err  error
+}
+
+func (p *pin) Err() error {
+	return p.err
 }
 
 func (p *pin) Path() path.Resolved {
@@ -44,7 +49,7 @@ func (api *PinAPI) Add(ctx context.Context, p path.Path, opts ...caopts.PinAddOp
 		Option("recursive", options.Recursive).Exec(ctx, nil)
 }
 
-func (api *PinAPI) Ls(ctx context.Context, opts ...caopts.PinLsOption) ([]iface.Pin, error) {
+func (api *PinAPI) Ls(ctx context.Context, opts ...caopts.PinLsOption) (<-chan iface.Pin, error) {
 	options, err := caopts.PinLsOptions(opts...)
 	if err != nil {
 		return nil, err
@@ -57,13 +62,13 @@ func (api *PinAPI) Ls(ctx context.Context, opts ...caopts.PinLsOption) ([]iface.
 		return nil, err
 	}
 
-	pins := make([]iface.Pin, 0, len(out.Keys))
+	pins := make(chan iface.Pin, len(out.Keys))
 	for hash, p := range out.Keys {
 		c, err := cid.Parse(hash)
 		if err != nil {
 			return nil, err
 		}
-		pins = append(pins, &pin{typ: p.Type, path: path.IpldPath(c)})
+		pins <- &pin{typ: p.Type, path: path.IpldPath(c)}
 	}
 
 	return pins, nil


### PR DESCRIPTION
https://github.com/ipfs/interface-go-ipfs-core master has a streaming pin ls API, however release branches have avoided it so far as a breaking change. This PR brings this library's implementation of the interface up to spec with the master branch.