### PR TITLE
feat: pubsub http rpc with multibase

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -6,7 +6,4 @@ runs:
   steps:
     - name: Install go-ipfs
       shell: bash
-      run: |
-        cd /tmp    && git clone https://github.com/coryschwartz/go-ipfs.git
-        cd go-ipfs && git checkout 153697d524f449ee9bec97245b0fcd7ebc2e8170
-        go install ./cmd/ipfs
+      run: (cd /tmp && go install github.com/ipfs/go-ipfs/cmd/ipfs@master)

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -4,6 +4,9 @@ description: install go-ipfs
 runs:
   using: "composite"
   steps:
-    - name: Step 1
+    - name: Install go-ipfs
       shell: bash
-      run: (cd /tmp && go install github.com/ipfs/go-ipfs/cmd/ipfs@master)
+      run: |
+        cd /tmp    && git clone https://github.com/coryschwartz/go-ipfs.git
+        cd go-ipfs && git checkout 153697d524f449ee9bec97245b0fcd7ebc2e8170
+        go install ./cmd/ipfs

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-ipfs-http-api
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
+[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.io/)
+[![](https://img.shields.io/badge/matrix-%23ipfs-blue.svg?style=flat-square)](https://app.element.io/#/room/#ipfs:matrix.org)
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 [![GoDoc](https://godoc.org/github.com/ipfs/go-ipfs-http-api?status.svg)](https://godoc.org/github.com/ipfs/go-ipfs-http-api)
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.8.6
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.3.3
+	github.com/multiformats/go-multibase v0.0.3
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/pkg/errors v0.9.1
 )


### PR DESCRIPTION
This updates HTTP RPC wire format to one from https://github.com/ipfs/go-ipfs/pull/8183

## BREAKING CHANGES

- peerid uses default text representation from go-libp2p
- byte fields sent over HTTP RPC are now encoded in multibase


## TODO

- [x] make tests from this PR pass with updated go-ipfs in https://github.com/ipfs/go-ipfs/pull/8183 
  - CI in this repo will be green when mentioned PR lands in go-ipfs@master: https://github.com/ipfs/go-ipfs-http-client/blob/master/.github/actions/go-test-setup/action.yml#L9
- [x] <del>decide if we prefer to keep public API unchanged, or switch topic names to be `[]byte`</del> descoped, keeping API unchanged
